### PR TITLE
feat: Support Python 3.7 type annotations

### DIFF
--- a/quill/classes/_tensor.py
+++ b/quill/classes/_tensor.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable
+from typing import Callable, List, Union
 from typing_extensions import Self
 from cupy import ndarray as cdarray, zeros
 from numpy import ndarray
@@ -7,7 +7,7 @@ from ..functions import type_check
 
 class Tensor:
 
-    def __init__(self, nd: ndarray, parents: list[Self] = [], grad_fn: Callable[[Self], None] = None, split_idx: int = -1) -> None:
+    def __init__(self, nd: ndarray, parents: List[Self] = [], grad_fn: Callable[[Self], None] = None, split_idx: int = -1) -> None:
 
         # TYPE CHECKS
         type_check(nd, "nd", cdarray)
@@ -15,7 +15,7 @@ class Tensor:
         type_check(split_idx, "split_idx", int)
         
         self.nd: ndarray = nd
-        self.parents: list[Tensor] = parents
+        self.parents: List[Tensor] = parents
         self.grad_fn: Callable = grad_fn
         self.grad: ndarray = zeros(nd.shape)
         self.split_idx: int = split_idx
@@ -23,7 +23,7 @@ class Tensor:
         self.n_backward: int = 0
         for parent in parents:
             parent.n_backward += 1
-        self.velocity: ndarray | None = None
+        self.velocity: Union[ndarray, None] = None
     
     def _zero_i_backward(self) -> None:
         if self.i_backward != 0:

--- a/quill/functions/_expr_check.py
+++ b/quill/functions/_expr_check.py
@@ -1,6 +1,5 @@
-from collections.abc import Callable
 from inspect import getsource
-from typing import TypeVar
+from typing import Callable, TypeVar
 
 T = TypeVar("T")
 

--- a/quill/functions/_type_check.py
+++ b/quill/functions/_type_check.py
@@ -1,10 +1,26 @@
-from collections.abc import Collection
-from typing import Any
+from typing import Any, Collection, Tuple, Union
 
-def type_check(obj: Any, nameof_obj: str, classinfo: Any, parameterized_generic_classinfo: Any | None = None) -> None:
-    if not isinstance(obj, classinfo):
+def type_check(obj: Any, nameof_obj: str, classinfo: Union[Any, Tuple[Any, ...]], parameterized_generic_classinfo: Union[Any, None] = None) -> None:
+    def _type_check(obj: Any, classinfo: Any, parameterized_generic_classinfo: Union[Any, None] = None) -> int:
+        if not isinstance(obj, classinfo):
+            return -1
+        if (parameterized_generic_classinfo is not None) and (isinstance(obj, Collection)):
+            for el in obj:
+                if not isinstance(el, parameterized_generic_classinfo):
+                    return -2
+        return 0
+    result: bool = False
+    if isinstance(classinfo, Collection):
+        for _classinfo in classinfo:
+            result = _type_check(obj, _classinfo, parameterized_generic_classinfo=parameterized_generic_classinfo)
+            if result == 0:
+                break
+            elif result == -2:
+                raise ValueError(f"{nameof_obj}` must be of type `{_classinfo.__name__}[{parameterized_generic_classinfo.__name__}]`, it cannot contain objects of types other than `{parameterized_generic_classinfo.__name__}`.")
         raise ValueError(f"`{nameof_obj}` must be of type `{classinfo.__name__}`, it cannot be of type `{type(obj).__name__}`.")
-    if (parameterized_generic_classinfo is not None) and (isinstance(obj, Collection)):
-        for el in obj:
-            if not isinstance(el, parameterized_generic_classinfo):
-                raise ValueError(f"{nameof_obj}` must be of type `{classinfo.__name__}[{parameterized_generic_classinfo.__name__}]`, it cannot contain objects of type `{type(el).__name__}`.")
+    else:
+        result = _type_check(obj, _classinfo, parameterized_generic_classinfo=parameterized_generic_classinfo)
+        if result == -1:
+            raise ValueError(f"`{nameof_obj}` must be of type `{classinfo.__name__}`, it cannot be of type `{type(obj).__name__}`.")
+        elif result == -2:
+            raise ValueError(f"{nameof_obj}` must be of type `{classinfo.__name__}[{parameterized_generic_classinfo.__name__}]`, it cannot contain objects of types other than `{parameterized_generic_classinfo.__name__}`.")

--- a/quill/nn/_avgpool2d.py
+++ b/quill/nn/_avgpool2d.py
@@ -1,4 +1,4 @@
-from collections.abc import Collection
+from typing import Collection, Tuple, Union
 
 from . import Module
 from .functional import avgpool3d
@@ -7,14 +7,14 @@ from ..functions import type_check, len_check, expr_check
 
 class AvgPool2d(Module):
 
-    def __init__(self, kernel_size: int | Collection[int], stride: int | Collection[int] | None = None) -> None:
+    def __init__(self, kernel_size: Union[int, Collection[int]], stride: Union[int, Collection[int], None] = None) -> None:
 
         # Initialize parent class
         super().__init__()
 
         # TYPE CHECKS
-        type_check(kernel_size, "kernel_size", (int | Collection), int)
-        type_check(stride, "stride", (int | Collection | None), int)
+        type_check(kernel_size, "kernel_size", (int, Collection), int)
+        type_check(stride, "stride", (int, Collection, None), int)
         
         # cast kernel_size and stride into tuple
         if isinstance(kernel_size, int):
@@ -34,8 +34,8 @@ class AvgPool2d(Module):
         for i_stride in range(len(stride)):
             expr_check(stride[i_stride], f"stride[{i_stride}]", lambda x: x > 0)
 
-        self.kernel_size: int | tuple[int, int] = kernel_size
-        self.stride: int | tuple[int, int] | None = stride
+        self.kernel_size: Union[int, Tuple[int, int]] = kernel_size
+        self.stride: Union[int, Tuple[int, int], None] = stride
     
     def forward(self, x: Tensor) -> Tensor:
         return avgpool3d(x, self.kernel_size, self.stride)

--- a/quill/nn/_conv2d.py
+++ b/quill/nn/_conv2d.py
@@ -1,4 +1,4 @@
-from collections.abc import Collection
+from typing import Collection, List, Tuple, Union
 from cupy.random import rand
 
 from . import Module
@@ -8,7 +8,7 @@ from ..functions import expr_check, len_check, type_check
 
 class Conv2d(Module):
 
-    def __init__(self, input_channels: int, output_channels: int, kernel_size: int | Collection[int], stride: int | Collection[int] = 1, padding: int | Collection[int] = 0, bias: bool = True):
+    def __init__(self, input_channels: int, output_channels: int, kernel_size: Union[int, Collection[int]], stride: Union[int, Collection[int]] = 1, padding: Union[int, Collection[int]] = 0, bias: bool = True):
 
         # Initialize parent class
         super().__init__()
@@ -16,9 +16,9 @@ class Conv2d(Module):
         # TYPE CHECKS
         type_check(input_channels, "input_channels", int)
         type_check(output_channels, "output_channels", int)
-        type_check(kernel_size, "kernel_size", (int | Collection), int)
-        type_check(stride, "stride", (int | Collection), int)
-        type_check(padding, "padding", (int | Collection), int)
+        type_check(kernel_size, "kernel_size", (int, Collection), int)
+        type_check(stride, "stride", (int, Collection), int)
+        type_check(padding, "padding", (int, Collection), int)
         type_check(bias, "bias", bool)
     
         # cast kernel_size, stride, padding into tuple
@@ -46,17 +46,17 @@ class Conv2d(Module):
 
         self.input_channels: int = input_channels
         self.output_channels: int = output_channels
-        self.kernel_size: tuple[int, int] = kernel_size
-        self.stride: tuple[int, int] = stride
-        self.padding: tuple[int, int] = padding
+        self.kernel_size: Tuple[int, int] = kernel_size
+        self.stride: Tuple[int, int] = stride
+        self.padding: Tuple[int, int] = padding
         
         self.weight: Tensor = Tensor(rand(output_channels, input_channels, kernel_size[0], kernel_size[1]))
-        self.bias: Tensor | None = None
+        self.bias: Union[Tensor, None] = None
         if bias:
             self.bias = Tensor(rand(output_channels))
 
     def forward(self, x: Tensor) -> Tensor:
-        _y: list[Tensor] = []
+        _y: List[Tensor] = []
         for w in unstack(self.weight, axis=0):
             _y.append(sum(conv3d(x, w, self.stride, self.padding), axis=-3))
         y: Tensor = stack(_y, axis=-3)

--- a/quill/nn/_linear.py
+++ b/quill/nn/_linear.py
@@ -1,3 +1,4 @@
+from typing import Union
 from cupy.random import rand
 
 from . import Module
@@ -25,7 +26,7 @@ class Linear(Module):
         self.output_size: int = output_size
 
         self.weight: Tensor = Tensor(rand(input_size, output_size))
-        self.bias: Tensor | None = None
+        self.bias: Union[Tensor, None] = None
         if bias:
             self.bias = Tensor(rand(output_size))
 

--- a/quill/nn/_maxpool2d.py
+++ b/quill/nn/_maxpool2d.py
@@ -1,4 +1,4 @@
-from collections.abc import Collection
+from typing import Collection, Tuple, Union
 
 from . import Module
 from .functional import maxpool3d
@@ -7,14 +7,14 @@ from ..functions import expr_check, len_check, type_check
 
 class MaxPool2d(Module):
 
-    def __init__(self, kernel_size: int | tuple[int, int], stride: int | tuple[int, int] | None = None) -> None:
+    def __init__(self, kernel_size: Union[int, Tuple[int, int]], stride: Union[int, Tuple[int, int], None] = None) -> None:
 
         # Initialize parent class
         super().__init__()
 
         # TYPE CHECKS
-        type_check(kernel_size, "kernel_size", (int | Collection), int)
-        type_check(stride, "stride", (int | Collection | None), int)
+        type_check(kernel_size, "kernel_size", (int, Collection), int)
+        type_check(stride, "stride", (int, Collection, None), int)
         
         # cast kernel_size and stride into tuple
         if isinstance(kernel_size, int):
@@ -34,8 +34,8 @@ class MaxPool2d(Module):
         for i_stride in range(len(stride)):
             expr_check(stride[i_stride], f"stride[{i_stride}]", lambda x: x > 0)
         
-        self.kernel_size: int | tuple[int, int] = kernel_size
-        self.stride: int | tuple[int, int] | None = stride
+        self.kernel_size: Union[int, Tuple[int, int]] = kernel_size
+        self.stride: Union[int, Tuple[int, int], None] = stride
     
     def forward(self, x: Tensor) -> Tensor:
         return maxpool3d(x, self.kernel_size, self.stride)

--- a/quill/nn/_module.py
+++ b/quill/nn/_module.py
@@ -1,8 +1,8 @@
-from typing import Any
+from typing import Any, Dict, Union
 
 from ..classes import Tensor
 
-_State = Tensor | dict[str, "_State"]
+_State = Union[Tensor, Dict[str, "_State"]]
 
 class Module:
 
@@ -18,8 +18,8 @@ class Module:
     def forward(self, x: Tensor, *args) -> Tensor:
         raise NotImplementedError(f"Forward function for module type {type(self).__name__} has not been implemented yet.")
 
-    def parameters(self) -> dict[str, _State]:
-        state_dict: dict[str, _State] = {}
+    def parameters(self) -> Dict[str, _State]:
+        state_dict: Dict[str, _State] = {}
         for k, v in vars(self).items():
             if isinstance(v, Tensor):
                 state_dict[k] = v
@@ -32,9 +32,9 @@ class Module:
 
     def __repr__(self) -> str:
         lines: str = f"{type(self).__name__}("
-        default_attributes: dict[str, Any] = vars(Module())
-        parameters: dict[str, Any] = {}
-        submodules: dict[str, Any] = {}
+        default_attributes: Dict[str, Any] = vars(Module())
+        parameters: Dict[str, Any] = {}
+        submodules: Dict[str, Any] = {}
         for k, v in vars(self).items():
             if k not in default_attributes:
                 if isinstance(v, Module):

--- a/quill/nn/_sequential.py
+++ b/quill/nn/_sequential.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from . import Module
 from ..classes import Tensor
 
@@ -5,7 +7,7 @@ class Sequential(Module):
 
     def __init__(self, *modules: Module) -> None:
         super().__init__()
-        self.modules: list[Module] = []
+        self.modules: List[Module] = []
         for module in modules:
             self.append(module)
     

--- a/quill/nn/functional/_addbias.py
+++ b/quill/nn/functional/_addbias.py
@@ -1,3 +1,4 @@
+from typing import List
 from cupy import sum
 
 from ...classes import Tensor
@@ -11,7 +12,7 @@ def addbias(x: Tensor, b: Tensor, axis: int = -1) -> Tensor:
     type_check(b, "b", Tensor)
 
     def grad_fn(child: Tensor) -> None:
-        axes: list[int] = list(range(x.grad.ndim))
+        axes: List[int] = list(range(x.grad.ndim))
         axes.pop(axis)
         x.grad += child.grad
         if len(axes) == 0:

--- a/quill/nn/functional/_avgpool3d.py
+++ b/quill/nn/functional/_avgpool3d.py
@@ -1,16 +1,16 @@
-from collections.abc import Collection
+from typing import Collection, Tuple, Union
 from cupy import mean, reciprocal, zeros
 from numpy import ndarray
 
 from ...classes import Tensor
 from ...functions import expr_check, len_check, type_check
 
-def avgpool3d(input_tensor: Tensor, kernel_size: int | Collection[int], stride: int | Collection[int] | None = None) -> Tensor:
+def avgpool3d(input_tensor: Tensor, kernel_size: Union[int, Collection[int]], stride: Union[int, Collection[int], None] = None) -> Tensor:
 
     # TYPE CHECKS
     type_check(input_tensor, "input_tensor", Tensor)
-    type_check(kernel_size, "kernel_size", (int | Collection), int)
-    type_check(stride, "stride", (int | Collection | None), int)
+    type_check(kernel_size, "kernel_size", (int, Collection), int)
+    type_check(stride, "stride", (int, Collection, None), int)
     
     # cast kernel_size and stride into tuple
     if isinstance(kernel_size, int):
@@ -35,7 +35,7 @@ def avgpool3d(input_tensor: Tensor, kernel_size: int | Collection[int], stride: 
     def _avgpool3d(input_nd: ndarray, kernel_size: Collection[int], stride: Collection[int]) -> ndarray:
 
         # get input dimensions
-        d_input_nd: tuple[int, int, int] | tuple[int, int, int, int] = input_nd.shape
+        d_input_nd: Union[Tuple[int, int, int], Tuple[int, int, int, int]] = input_nd.shape
 
         # create output image
         output_nd_height: int = ((d_input_nd[-2] - kernel_size[-2]) // stride[-2]) + 1
@@ -50,8 +50,8 @@ def avgpool3d(input_tensor: Tensor, kernel_size: int | Collection[int], stride: 
         return output_nd
 
     def grad_fn(child: Tensor) -> None:
-        d_input_grad: tuple[int, int, int] | tuple[int, int, int, int] = input_tensor.grad.shape
-        d_child_grad: tuple[int, int, int] | tuple[int, int, int, int] = child.grad.shape
+        d_input_grad: Union[Tuple[int, int, int], Tuple[int, int, int, int]] = input_tensor.grad.shape
+        d_child_grad: Union[Tuple[int, int, int], Tuple[int, int, int, int]] = child.grad.shape
         for i_child_grad, i_input_grad in zip(range(d_child_grad[-2]), range(0, (d_input_grad[-2] - kernel_size[-2] + 1), stride[-2])):
             for j_child_grad, j_input_grad in zip(range(d_child_grad[-1]), range(0, (d_input_grad[-1] - kernel_size[-1] + 1), stride[-1])):
                 input_tensor.grad[..., i_input_grad:(i_input_grad + kernel_size[-2]), j_input_grad:(j_input_grad + kernel_size[-1])] += child.grad[..., None, None, i_child_grad, j_child_grad] * reciprocal(float(kernel_size[-2] * kernel_size[-1]))

--- a/quill/nn/functional/_concatenate.py
+++ b/quill/nn/functional/_concatenate.py
@@ -1,4 +1,4 @@
-from collections.abc import Collection
+from typing import Collection, List
 from cupy import concatenate as _concatenate, split
 from numpy import ndarray
 
@@ -14,7 +14,7 @@ def concatenate(tensors: Collection[Tensor], axis: int = 0) -> Tensor:
     type_check(axis, "axis", int)
 
     def grad_fn(child: Tensor) -> None:
-        _child_grad: list[ndarray] = [_grad for _grad in split(child.grad, len(tensors), axis)]
+        _child_grad: List[ndarray] = [_grad for _grad in split(child.grad, len(tensors), axis)]
         for i_tensor in range(len(tensors)):
             tensors[i_tensor].grad += _child_grad[i_tensor]
 

--- a/quill/nn/functional/_maxpool3d.py
+++ b/quill/nn/functional/_maxpool3d.py
@@ -1,16 +1,16 @@
-from collections.abc import Collection
+from typing import Collection, Tuple, Union
 from cupy import amax, argmax, unravel_index, zeros
 from numpy import ndarray
 
 from ...classes import Tensor
 from ...functions import expr_check, len_check, type_check
 
-def maxpool3d(input_tensor: Tensor, kernel_size: int | Collection[int], stride: int | Collection[int] | None = None) -> Tensor:
+def maxpool3d(input_tensor: Tensor, kernel_size: Union[int, Collection[int]], stride: Union[int, Collection[int], None] = None) -> Tensor:
 
     # TYPE CHECKS
     type_check(input_tensor, "input_tensor", Tensor)
-    type_check(kernel_size, "kernel_size", (int | Collection), int)
-    type_check(stride, "stride", (int | Collection | None), int)
+    type_check(kernel_size, "kernel_size", (int, Collection), int)
+    type_check(stride, "stride", (int, Collection, None), int)
     
     # cast kernel_size and stride into tuple
     if isinstance(kernel_size, int):
@@ -35,7 +35,7 @@ def maxpool3d(input_tensor: Tensor, kernel_size: int | Collection[int], stride: 
     def _maxpool3d(input_nd: ndarray, kernel_size: Collection[int], stride: Collection[int]) -> ndarray:
 
         # get input dimensions
-        d_input_nd: tuple[int, int, int] | tuple[int, int, int, int] = input_nd.shape
+        d_input_nd: Union[Tuple[int, int, int], Tuple[int, int, int, int]] = input_nd.shape
 
         # create output image
         output_nd_height: int = ((d_input_nd[-2] - kernel_size[-2]) // stride[-2]) + 1
@@ -51,8 +51,8 @@ def maxpool3d(input_tensor: Tensor, kernel_size: int | Collection[int], stride: 
         return output_nd
 
     def grad_fn(child: Tensor) -> None:
-        d_input: tuple[int, int, int] | tuple[int, int, int, int] = input_tensor.nd.shape
-        d_child_grad: tuple[int, int, int] | tuple[int, int, int, int] = child.grad.shape
+        d_input: Union[Tuple[int, int, int], Tuple[int, int, int, int]] = input_tensor.nd.shape
+        d_child_grad: Union[Tuple[int, int, int], Tuple[int, int, int, int]] = child.grad.shape
         if input_tensor.grad.ndim == 3:
             for input_nd_matrix, input_grad_matrix, child_grad_matrix in zip(input_tensor.nd, input_tensor.grad, child.grad):
                 for i_child_grad, i_input in zip(range(d_child_grad[-2]), range(0, (d_input[-2] - kernel_size[-2] + 1), stride[-2])):

--- a/quill/nn/functional/_split.py
+++ b/quill/nn/functional/_split.py
@@ -1,9 +1,10 @@
+from typing import List
 from cupy import split as _split
 
 from ...classes import Tensor
 from ...functions import type_check
 
-def split(tensor: Tensor, indices_or_sections: int, axis: int = 0) -> list[Tensor]:
+def split(tensor: Tensor, indices_or_sections: int, axis: int = 0) -> List[Tensor]:
 
     # TYPE CHECKS
     # tensor must be a Tensor

--- a/quill/nn/functional/_stack.py
+++ b/quill/nn/functional/_stack.py
@@ -1,4 +1,4 @@
-from collections.abc import Collection
+from typing import Collection, List
 from cupy import split, squeeze, stack as _stack
 from numpy import ndarray
 
@@ -14,7 +14,7 @@ def stack(tensors: Collection[Tensor], axis: int = 0) -> Tensor:
     type_check(axis, "axis", int)
 
     def grad_fn(child: Tensor) -> None:
-        _child_grad: list[ndarray] = [squeeze(_grad, axis) for _grad in split(child.grad, child.grad.shape[axis], axis)]
+        _child_grad: List[ndarray] = [squeeze(_grad, axis) for _grad in split(child.grad, child.grad.shape[axis], axis)]
         for i_tensor in range(len(tensors)):
             tensors[i_tensor].grad += _child_grad[i_tensor]
 

--- a/quill/nn/functional/_unstack.py
+++ b/quill/nn/functional/_unstack.py
@@ -1,9 +1,10 @@
+from typing import List
 from cupy import split, squeeze
 
 from ...classes import Tensor
 from ...functions import type_check
 
-def unstack(tensor: Tensor, axis: int = 0) -> list[Tensor]:
+def unstack(tensor: Tensor, axis: int = 0) -> List[Tensor]:
 
     # TYPE CHECKS
     # tensor must be a Tensor

--- a/quill/optim/_optimizer.py
+++ b/quill/optim/_optimizer.py
@@ -1,18 +1,18 @@
-from collections.abc import Callable
+from typing import Callable, Dict, List, Set, Union
 from cupy import zeros
 
 from ..classes import Tensor
 
-_State = Tensor | dict[str, "_State"]
+_State = Union[Tensor, Dict[str, "_State"]]
 
 class Optimizer:
 
-    def __init__(self, params: dict[str, _State]) -> None:
-        self.params: dict[str, _State] = params
+    def __init__(self, params: Dict[str, _State]) -> None:
+        self.params: Dict[str, _State] = params
     
     def _modify_params(self, expr: Callable[[Tensor], None]) -> None:
-        values: list[_State] = list(self.params.values())
-        visited: set[_State] = set()
+        values: List[_State] = list(self.params.values())
+        visited: Set[_State] = set()
         while len(values) > 0:
             v = values.pop(0)
             if isinstance(v, dict):

--- a/quill/optim/_sgd.py
+++ b/quill/optim/_sgd.py
@@ -1,11 +1,13 @@
+from typing import Dict, Union
+
 from . import Optimizer
 from ..classes import Tensor
 
-_State = Tensor | dict[str, "_State"]
+_State = Union[Tensor, Dict[str, "_State"]]
 
 class SGD(Optimizer):
 
-    def __init__(self, params: dict[str, _State], lr: float = 0.001, momentum: float = 0.):
+    def __init__(self, params: Dict[str, _State], lr: float = 0.001, momentum: float = 0.):
         super().__init__(params)
         self.lr: float = lr
         self.momentum: float = momentum

--- a/quill/utils/data/_dataloader.py
+++ b/quill/utils/data/_dataloader.py
@@ -1,4 +1,4 @@
-from collections.abc import Generator
+from typing import Generator, List, Tuple
 from random import shuffle
 
 from . import Dataset
@@ -12,9 +12,9 @@ class DataLoader:
         self.batch_size: int = batch_size
         self.shuffle: bool = shuffle
 
-    def __iter__(self) -> Generator[tuple[Tensor, ...], None, None]:
+    def __iter__(self) -> Generator[Tuple[Tensor, ...], None, None]:
         dataset_size: int = len(self.dataset)
-        start_indices: list[int] = list(range(0, dataset_size, self.batch_size))
+        start_indices: List[int] = list(range(0, dataset_size, self.batch_size))
         if self.shuffle:
             shuffle(start_indices)
         yield from (tuple(stack(column) for column in zip(*(self.dataset[idx] for idx in range(start_idx, min(start_idx + self.batch_size, dataset_size))))) for start_idx in start_indices)


### PR DESCRIPTION
Generally,
- change collections.abc imports to typing (except on quill.utils.data.Dataset, because collections.abc import is used for inheriting an abstract base class, not for type annotation)
- dict, list, set, and tuple type annotations are now Dict, List, Set, and Tuple (all 4 classes are imported from typing)
- union type annotations (type1 | type2 | ... | typeN) are now Union[type1, type2, ..., typeN]; Union is an imported class from typing
- isinstance cannot accept Unions, so quill.functions.type_check has to be modified