### PR TITLE
fix: tuple type annotation in reshape

### DIFF
--- a/quill/nn/functional/_concatenate.py
+++ b/quill/nn/functional/_concatenate.py
@@ -8,7 +8,7 @@ from ...functions import type_check
 def concatenate(tensors: Sequence[Tensor], axis: int = 0) -> Tensor:
 
     # TYPE CHECKS
-    # tensors must be a list of Tensors
+    # tensors must be a sequence of Tensors
     # axis must be an int
     type_check(tensors, "tensors", Sequence, Tensor)
     type_check(axis, "axis", int)

--- a/quill/nn/functional/_reshape.py
+++ b/quill/nn/functional/_reshape.py
@@ -3,11 +3,11 @@ from typing import Sequence
 from ...classes import Tensor
 from ...functions import type_check
 
-def reshape(x: Tensor, newshape: tuple[int]) -> Tensor:
+def reshape(x: Tensor, newshape: Sequence[int]) -> Tensor:
 
     # TYPE CHECKS
     # x must be a Tensor
-    # newshape must be a tuple of ints
+    # newshape must be a sequence of ints
     type_check(x, "x", Tensor)
     type_check(newshape, "newshape", Sequence, int)
 

--- a/quill/nn/functional/_stack.py
+++ b/quill/nn/functional/_stack.py
@@ -8,7 +8,7 @@ from ...functions import type_check
 def stack(tensors: Sequence[Tensor], axis: int = 0) -> Tensor:
 
     # TYPE CHECKS
-    # tensors must be a list of Tensors
+    # tensors must be a sequence of Tensors
     # axis must be an int
     type_check(tensors, "tensors", Sequence, Tensor)
     type_check(axis, "axis", int)


### PR DESCRIPTION
quill.nn.functional.reshape
- fix: change tuple type annotation into Sequence
- chore: change tuple --> sequence in comments

quill.nn.functional.concatenate
- chore: change list --> sequence in comments

quill.nn.functional.stack
- chore: change list --> sequence in comments

Co-Authored-By: Jonathan Richard Sugandhi <64012903+jonathanrichard13@users.noreply.github.com>