### PR TITLE
fix: type_check raising errors whenever classinfo is a Collection

### DIFF
--- a/quill/functions/_type_check.py
+++ b/quill/functions/_type_check.py
@@ -9,7 +9,7 @@ def type_check(obj: Any, nameof_obj: str, classinfo: Union[Any, Tuple[Any, ...]]
                 if not isinstance(el, parameterized_generic_classinfo):
                     return -2
         return 0
-    result: bool = False
+    result: int = -1
     if isinstance(classinfo, Collection):
         for _classinfo in classinfo:
             result = _type_check(obj, _classinfo, parameterized_generic_classinfo=parameterized_generic_classinfo)
@@ -17,7 +17,8 @@ def type_check(obj: Any, nameof_obj: str, classinfo: Union[Any, Tuple[Any, ...]]
                 break
             elif result == -2:
                 raise ValueError(f"{nameof_obj}` must be of type `{_classinfo.__name__}[{parameterized_generic_classinfo.__name__}]`, it cannot contain objects of types other than `{parameterized_generic_classinfo.__name__}`.")
-        raise ValueError(f"`{nameof_obj}` must be of type `{classinfo.__name__}`, it cannot be of type `{type(obj).__name__}`.")
+        if result != 0:
+            raise ValueError(f"`{nameof_obj}` must be one of these types: `{classinfo}`, it cannot be of type `{type(obj).__name__}`.")
     else:
         result = _type_check(obj, classinfo, parameterized_generic_classinfo=parameterized_generic_classinfo)
         if result == -1:

--- a/quill/utils/data/_dataloader.py
+++ b/quill/utils/data/_dataloader.py
@@ -7,7 +7,7 @@ from ...nn.functional import stack
 
 class DataLoader:
 
-    def __init__(self, dataset: Dataset, batch_size: int = 1, shuffle: bool = True) -> None:
+    def __init__(self, dataset: Dataset, batch_size: int = 1, shuffle: bool = False) -> None:
         self.dataset: Dataset = dataset
         self.batch_size: int = batch_size
         self.shuffle: bool = shuffle


### PR DESCRIPTION
quill.functions.type_check
- fix: type_check will no longer raise incorrect errors if classinfo is a Collection