### PR TITLE
fix: type_check with tuple of classes for classinfo

### DIFF
--- a/quill/functions/_type_check.py
+++ b/quill/functions/_type_check.py
@@ -1,27 +1,15 @@
 from typing import Any, Collection, Tuple, Union
 
 def type_check(obj: Any, nameof_obj: str, classinfo: Union[Any, Tuple[Any, ...]], parameterized_generic_classinfo: Union[Any, None] = None) -> None:
-    def _type_check(obj: Any, classinfo: Any, parameterized_generic_classinfo: Union[Any, None] = None) -> int:
-        if not isinstance(obj, classinfo):
-            return -1
-        if (parameterized_generic_classinfo is not None) and (isinstance(obj, Collection)):
-            for el in obj:
-                if not isinstance(el, parameterized_generic_classinfo):
-                    return -2
-        return 0
-    result: int = -1
-    if isinstance(classinfo, Collection):
-        for _classinfo in classinfo:
-            result = _type_check(obj, _classinfo, parameterized_generic_classinfo=parameterized_generic_classinfo)
-            if result == 0:
-                break
-            elif result == -2:
-                raise ValueError(f"{nameof_obj}` must be of type `{_classinfo.__name__}[{parameterized_generic_classinfo.__name__}]`, it cannot contain objects of types other than `{parameterized_generic_classinfo.__name__}`.")
-        if result != 0:
+    if not isinstance(obj, classinfo):
+        if isinstance(classinfo, Collection):
             raise ValueError(f"`{nameof_obj}` must be one of these types: `{classinfo}`, it cannot be of type `{type(obj).__name__}`.")
-    else:
-        result = _type_check(obj, classinfo, parameterized_generic_classinfo=parameterized_generic_classinfo)
-        if result == -1:
+        else:
             raise ValueError(f"`{nameof_obj}` must be of type `{classinfo.__name__}`, it cannot be of type `{type(obj).__name__}`.")
-        elif result == -2:
-            raise ValueError(f"{nameof_obj}` must be of type `{classinfo.__name__}[{parameterized_generic_classinfo.__name__}]`, it cannot contain objects of types other than `{parameterized_generic_classinfo.__name__}`.")
+    elif (parameterized_generic_classinfo is not None) and (isinstance(obj, Collection)):
+        for el in obj:
+            if not isinstance(el, parameterized_generic_classinfo):
+                if isinstance(classinfo, Collection):
+                    raise ValueError(f"{nameof_obj}` must be one of these types `{classinfo}[{parameterized_generic_classinfo.__name__}]`, it cannot contain objects of type `{type(el).__name__}`.")
+                else:    
+                    raise ValueError(f"{nameof_obj}` must be of type `{classinfo.__name__}[{parameterized_generic_classinfo.__name__}]`, it cannot contain objects of type `{type(el).__name__}`.")

--- a/quill/functions/_type_check.py
+++ b/quill/functions/_type_check.py
@@ -4,7 +4,7 @@ from typing import Any
 def type_check(obj: Any, nameof_obj: str, classinfo: Any, parameterized_generic_classinfo: Any | None = None) -> None:
     if not isinstance(obj, classinfo):
         raise ValueError(f"`{nameof_obj}` must be of type `{classinfo.__name__}`, it cannot be of type `{type(obj).__name__}`.")
-    if (parameterized_generic_classinfo is not None) and (isinstance(obj, Collection)):
+    elif (parameterized_generic_classinfo is not None) and (isinstance(obj, Collection)):
         for el in obj:
             if not isinstance(el, parameterized_generic_classinfo):
                 raise ValueError(f"{nameof_obj}` must be of type `{classinfo.__name__}[{parameterized_generic_classinfo.__name__}]`, it cannot contain objects of type `{type(el).__name__}`.")

--- a/quill/nn/_avgpool2d.py
+++ b/quill/nn/_avgpool2d.py
@@ -14,7 +14,7 @@ class AvgPool2d(Module):
 
         # TYPE CHECKS
         type_check(kernel_size, "kernel_size", (int, Sequence), int)
-        type_check(stride, "stride", (int, Sequence, None), int)
+        type_check(stride, "stride", (int, Sequence, type(None)), int)
         
         # cast kernel_size and stride into tuple
         if isinstance(kernel_size, int):

--- a/quill/nn/_maxpool2d.py
+++ b/quill/nn/_maxpool2d.py
@@ -14,7 +14,7 @@ class MaxPool2d(Module):
 
         # TYPE CHECKS
         type_check(kernel_size, "kernel_size", (int, Sequence), int)
-        type_check(stride, "stride", (int, Sequence, None), int)
+        type_check(stride, "stride", (int, Sequence, type(None)), int)
         
         # cast kernel_size and stride into tuple
         if isinstance(kernel_size, int):

--- a/quill/nn/functional/_avgpool3d.py
+++ b/quill/nn/functional/_avgpool3d.py
@@ -10,7 +10,7 @@ def avgpool3d(input_tensor: Tensor, kernel_size: Union[int, Sequence[int]], stri
     # TYPE CHECKS
     type_check(input_tensor, "input_tensor", Tensor)
     type_check(kernel_size, "kernel_size", (int, Sequence), int)
-    type_check(stride, "stride", (int, Sequence, None), int)
+    type_check(stride, "stride", (int, Sequence, type(None)), int)
     
     # cast kernel_size and stride into tuple
     if isinstance(kernel_size, int):

--- a/quill/nn/functional/_maxpool3d.py
+++ b/quill/nn/functional/_maxpool3d.py
@@ -10,7 +10,7 @@ def maxpool3d(input_tensor: Tensor, kernel_size: Union[int, Sequence[int]], stri
     # TYPE CHECKS
     type_check(input_tensor, "input_tensor", Tensor)
     type_check(kernel_size, "kernel_size", (int, Sequence), int)
-    type_check(stride, "stride", (int, Sequence, None), int)
+    type_check(stride, "stride", (int, Sequence, type(None)), int)
     
     # cast kernel_size and stride into tuple
     if isinstance(kernel_size, int):


### PR DESCRIPTION
quill.functions.type_check
- fix: revert to upstream algorithm, since isinstance accepts tuple of classes for classinfo argument

quill.nn.AvgPool2d
- fix: use (..., type(None)) instead of (..., None) for classinfo argument on corresponding type_checks

quill.nn.MaxPool2d
- fix: use (..., type(None)) instead of (..., None) for classinfo argument on corresponding type_checks

quill.nn.functional.avgpool3d
- fix: use (..., type(None)) instead of (..., None) for classinfo argument on corresponding type_checks

quill.nn.functional.maxpool3d
- fix: use (..., type(None)) instead of (..., None) for classinfo argument on corresponding type_checks

Co-Authored-By: Jonathan Richard Sugandhi <64012903+jonathanrichard13@users.noreply.github.com>